### PR TITLE
Install Debian ca-certificates package

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into the default branch
-      - uses: release-drafter/release-drafter@v5.23.0
+      - uses: release-drafter/release-drafter@v5.24.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.31.0
+        uses: updatecli/updatecli-action@v2.32.0
 
       - name: Run Updatecli in Dry Run mode
         run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test-%: prepare-test
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
 	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18-alpine \
-		sh -c "npm install -g npm@9.6.3 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
+		sh -c "npm install -g npm@9.7.2 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -54,6 +54,7 @@ RUN groupadd -g ${gid} ${group} \
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
+        ca-certificates \
         git-lfs \
         less \
         netcat-traditional \

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -193,7 +193,7 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
   assert_success
 }
 
-@test "[${SUT_IMAGE}] image has required tools installed and present in the PATH" {
+@test "[${SUT_IMAGE}] image has required tools installed and present in the PATH and can clone agent repo" {
   local test_container_name=${AGENT_CONTAINER}-bash-java
   clean_test_container "${test_container_name}"
   docker run --name="${test_container_name}" --name="${test_container_name}" "${docker_run_opts[@]}" "${PUBLIC_SSH_KEY}"
@@ -215,6 +215,9 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
   run docker exec "${test_container_name}" sh -c "command -v patch"
   assert_success
   run docker exec "${test_container_name}" patch --version
+  assert_success
+
+  run docker exec "${test_container_name}" git clone https://github.com/jenkinsci/docker-ssh-agent.git
   assert_success
 
   clean_test_container "${test_container_name}"


### PR DESCRIPTION
## Install Debian ca-certificates package

Fix #265 - Unable to clone https repo due to missing ca-certificates

Also updates the version of npm used for test reporting in order to silence a warning and includes a test that shows the failure without the fix.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

